### PR TITLE
Fix Beyond the Horizon image link

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -54,7 +54,7 @@
     "force_down": true,
     "links": {
       "$type": "Links, Wabbajack.Lib",
-      "image": "https://raw.githubusercontent.com/nemal34/beyondthehorizon_wj/main/bth.jpg",
+      "image": "https://raw.githubusercontent.com/nemal34/beyondthehorizon_wj/main/bth/bth.jpg",
       "readme": "https://raw.githubusercontent.com/nemal34/beyondthehorizon_wj/main/README.md",
       "download": "https://authored-files.wabbajack.org/Beyond%20the%20Horizon.wabbajack_cf4974d3-8423-4910-9950-4a8250fd6197",
       "machineURL": "BtHz",


### PR DESCRIPTION
Noticed your image wasn't loading in the gallery, but the link is dead since the path is not correct